### PR TITLE
handle removing the Number trait bound from CDatatype

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ rust-version = "1.65"
 
 [dependencies]
 
-custos = {git = "https://github.com/elftausend/custos", default-features = false, features=["macro"] }
-#custos = { path = "../custos", default-features = false, features=["macro"] }
+#custos = {git = "https://github.com/elftausend/custos", default-features = false, features=["macro"] }
+custos = { path = "../custos", default-features = false, features=["macro"] }
 #custos = { version = "0.6.3", default-features = false, features=["macro"] }
 
 

--- a/src/cuda.rs
+++ b/src/cuda.rs
@@ -1,10 +1,12 @@
 use crate::Matrix;
 use custos::{
-    cache::Cache, cuda::launch_kernel1d, prelude::CUBuffer, CDatatype, Device, Read, WriteBuf, CPU,
-    CUDA,
+    cache::Cache,
+    cuda::launch_kernel1d,
+    prelude::{CUBuffer, Number},
+    CDatatype, Device, Read, WriteBuf, CPU, CUDA,
 };
 
-pub fn cu_scalar_op<'a, T: CDatatype>(
+pub fn cu_scalar_op<'a, T: CDatatype + Number>(
     device: &'a CUDA,
     lhs: &CUBuffer<T>,
     rhs: T,

--- a/src/opencl.rs
+++ b/src/opencl.rs
@@ -1,6 +1,7 @@
 //mod switching;
 //pub use switching::*;
 
+use custos::number::Number;
 use custos::{
     devices::opencl::cl_device::OpenCL,
     opencl::{
@@ -25,7 +26,7 @@ pub fn cl_str_op_mat<'a, T: CDatatype>(
     Ok((out, x.dims()).into())
 }
 
-pub fn cl_scalar_op_mat<'a, T: CDatatype>(
+pub fn cl_scalar_op_mat<'a, T: CDatatype + Number>(
     device: &'a OpenCL,
     x: &Matrix<T, OpenCL>,
     scalar: T,

--- a/src/ops/clip.rs
+++ b/src/ops/clip.rs
@@ -40,7 +40,7 @@ impl<T: Number, D: MainMemory, S: Shape> ClipOp<T, S, D> for CPU {
 }
 
 #[cfg(feature = "opencl")]
-fn cl_clip<'a, T: CDatatype>(
+fn cl_clip<'a, T: CDatatype + Number>(
     device: &'a OpenCL,
     x: &Matrix<T, OpenCL>,
     min: T,
@@ -73,14 +73,14 @@ fn cl_clip<'a, T: CDatatype>(
 }
 
 #[cfg(feature = "opencl")]
-impl<T: CDatatype> ClipOp<T> for OpenCL {
+impl<T: CDatatype + Number> ClipOp<T> for OpenCL {
     fn clip(&self, x: &Matrix<T, Self>, min: T, max: T) -> Matrix<T, Self> {
         cl_clip(self, x, min, max).unwrap()
     }
 }
 
 #[cfg(feature = "cuda")]
-pub fn cu_clip<'a, T: CDatatype>(
+pub fn cu_clip<'a, T: CDatatype + Number>(
     device: &'a CUDA,
     x: &Buffer<T, CUDA>,
     min: T,
@@ -118,7 +118,7 @@ pub fn cu_clip<'a, T: CDatatype>(
 }
 
 #[cfg(feature = "cuda")]
-impl<T: CDatatype> ClipOp<T> for CUDA {
+impl<T: CDatatype + Number> ClipOp<T> for CUDA {
     fn clip(&self, x: &Matrix<T, CUDA>, min: T, max: T) -> Matrix<T, CUDA> {
         let buf = cu_clip(self, x, min, max).unwrap();
         (buf, x.dims()).into()

--- a/src/ops/col_op.rs
+++ b/src/ops/col_op.rs
@@ -31,7 +31,7 @@ impl<T: Number, D: MainMemory> ColOp<T, D> for CPU {
 }
 
 #[cfg(feature = "opencl")]
-impl<T: custos::CDatatype> ColOp<T> for OpenCL {
+impl<T: custos::CDatatype + Number> ColOp<T> for OpenCL {
     #[inline]
     fn add_col(&self, lhs: &Matrix<T, Self>, rhs: &Matrix<T, Self>) -> Matrix<T, Self> {
         cl_to_cpu_lr(self, lhs, rhs, |device, lhs, rhs| device.add_col(lhs, rhs))
@@ -53,7 +53,7 @@ use crate::cu_to_cpu_lr;
 use custos::CUDA;
 
 #[cfg(feature = "cuda")]
-impl<T: custos::CDatatype> ColOp<T> for CUDA {
+impl<T: custos::CDatatype + Number> ColOp<T> for CUDA {
     #[inline]
     fn add_col(&self, lhs: &Matrix<T, Self>, rhs: &Matrix<T, Self>) -> Matrix<T, Self> {
         cu_to_cpu_lr(self, lhs, rhs, |device, lhs, rhs| device.add_col(lhs, rhs))

--- a/src/ops/diagflat.rs
+++ b/src/ops/diagflat.rs
@@ -3,7 +3,7 @@ use crate::cu_to_cpu_s;
 use crate::Matrix;
 #[cfg(feature = "cuda")]
 use custos::CUDA;
-use custos::{CDatatype, Device, MainMemory};
+use custos::{CDatatype, Device, MainMemory, number::Number};
 
 #[cfg(feature = "cpu")]
 use custos::{cache::Cache, cpu::CPU};
@@ -50,7 +50,7 @@ impl<T: Copy + Default> DiagflatOp<T> for CUDA {
 }
 
 #[cfg(feature = "opencl")]
-impl<T: CDatatype> DiagflatOp<T> for OpenCL {
+impl<T: CDatatype + Number> DiagflatOp<T> for OpenCL {
     #[inline]
     fn diagflat(&self, x: &Matrix<T, Self>) -> Matrix<T, Self> {
         cl_to_cpu_s(self, x, |device, x| device.diagflat(x))

--- a/src/ops/fns.rs
+++ b/src/ops/fns.rs
@@ -1,4 +1,4 @@
-use custos::{impl_stack, number::Float, CDatatype, Device, MainMemory, Shape};
+use custos::{impl_stack, number::Float, number::Number, CDatatype, Device, MainMemory, Shape};
 
 #[cfg(feature = "cpu")]
 use custos::CPU;
@@ -87,7 +87,7 @@ where
 }
 
 #[cfg(feature = "opencl")]
-impl<T: CDatatype> FnsOps<T> for OpenCL {
+impl<T: CDatatype + Number> FnsOps<T> for OpenCL {
     #[inline]
     fn exp(&self, x: &Matrix<T, Self>) -> Matrix<T, Self> {
         cl_str_op_mat(self, x, "exp(x)").unwrap()
@@ -115,7 +115,7 @@ impl<T: CDatatype> FnsOps<T> for OpenCL {
 }
 
 #[cfg(feature = "cuda")]
-impl<T: CDatatype> FnsOps<T> for CUDA {
+impl<T: CDatatype + Number> FnsOps<T> for CUDA {
     #[inline]
     fn exp(&self, x: &Matrix<T, Self>) -> Matrix<T, Self> {
         let out = cu_str_op(self, x, "exp(x)").unwrap();

--- a/src/ops/max.rs
+++ b/src/ops/max.rs
@@ -96,7 +96,7 @@ impl<T: Copy + PartialOrd, D: MainMemory> MaxOps<T, D> for CPU {
 }
 
 #[cfg(feature = "opencl")]
-impl<T: CDatatype> MaxOps<T> for OpenCL {
+impl<T: CDatatype + Number> MaxOps<T> for OpenCL {
     fn max(&self, x: &Matrix<T, Self>) -> T {
         cl_to_cpu_scalar(self, x, |device, x| device.max(x))
     }

--- a/src/ops/nn/loss/mse.rs
+++ b/src/ops/nn/loss/mse.rs
@@ -40,7 +40,7 @@ where
 }
 
 #[cfg(feature = "opencl")]
-pub fn mse_grad_cl<'a, T: CDatatype>(
+pub fn mse_grad_cl<'a, T: CDatatype + Number>(
     device: &'a OpenCL,
     preds: &Matrix<'a, T, OpenCL>,
     targets: &Matrix<'a, T, OpenCL>,
@@ -66,6 +66,7 @@ pub fn mse_grad_cl<'a, T: CDatatype>(
 
     let out: custos::Buffer<T, OpenCL> =
         device.retrieve(preds.len(), (preds.node.idx, targets.node.idx));
+
     enqueue_kernel(
         device,
         &src,
@@ -80,5 +81,6 @@ pub fn mse_grad_cl<'a, T: CDatatype>(
         ],
     )
     .unwrap();
+
     (out, preds.dims()).into()
 }

--- a/src/ops/nn/softmax.rs
+++ b/src/ops/nn/softmax.rs
@@ -6,7 +6,7 @@ use crate::{
 use crate::{
     matrix_multiply::MatrixMultiply, ColOp, FnsOps, Matrix, MaxOps, SumOverOps, TransposeOp,
 };
-use custos::{number::Float, range, Device, GenericBlas, CPU};
+use custos::{number::{Float, Number}, range, Device, GenericBlas, CPU};
 #[cfg(feature = "opencl")]
 use custos::{CDatatype, OpenCL};
 
@@ -150,7 +150,7 @@ impl<T: GenericBlas + MatrixMultiply + Float> SoftmaxOps<T> for OpenCL {
 }
 
 #[cfg(feature = "opencl")]
-pub fn cl_softmax<'a, T: CDatatype>(
+pub fn cl_softmax<'a, T: CDatatype + Number>(
     device: &'a OpenCL,
     mut activated: Matrix<T, OpenCL>,
     grads: &Matrix<T, OpenCL>,

--- a/src/ops/row_op.rs
+++ b/src/ops/row_op.rs
@@ -57,7 +57,7 @@ impl<T: Number, D: MainMemory, LS: Shape, RS: Shape> RowOp<T, LS, RS, D> for CPU
 
 // TODO: Implement add_ro_mut (for cuda as well)
 #[cfg(feature = "opencl")]
-impl<T: CDatatype> RowOp<T> for OpenCL {
+impl<T: CDatatype + Number> RowOp<T> for OpenCL {
     #[inline]
     fn add_row(&self, lhs: &Matrix<T, Self>, rhs: &Matrix<T, Self>) -> Matrix<T, Self> {
         cl_to_cpu_lr(self, lhs, rhs, |device, lhs, rhs| device.add_row(lhs, rhs))
@@ -71,7 +71,7 @@ impl<T: CDatatype> RowOp<T> for OpenCL {
 }
 
 #[cfg(feature = "cuda")]
-impl<T: CDatatype> RowOp<T> for CUDA {
+impl<T: CDatatype + Number> RowOp<T> for CUDA {
     #[inline]
     fn add_row(&self, lhs: &Matrix<T, CUDA>, rhs: &Matrix<T, CUDA>) -> Matrix<T, CUDA> {
         cu_to_cpu_lr(self, lhs, rhs, |device, lhs, rhs| device.add_row(lhs, rhs))

--- a/src/ops/scalar.rs
+++ b/src/ops/scalar.rs
@@ -57,7 +57,7 @@ pub trait AdditionalOps<T, S: Shape = (), D: Device = Self>: Device {
 }
 
 #[cfg(feature = "cuda")]
-impl<T: CDatatype> AdditionalOps<T> for CUDA {
+impl<T: CDatatype + Number> AdditionalOps<T> for CUDA {
     #[inline]
     fn adds(&self, lhs: &Matrix<T, CUDA>, rhs: T) -> Matrix<T, CUDA> {
         (cu_scalar_op(self, lhs, rhs, "+").unwrap(), lhs.dims()).into()
@@ -85,7 +85,7 @@ impl<T: CDatatype> AdditionalOps<T> for CUDA {
 }
 
 #[cfg(feature = "opencl")]
-impl<T: CDatatype> AdditionalOps<T> for OpenCL {
+impl<T: CDatatype + Number> AdditionalOps<T> for OpenCL {
     #[inline]
     fn adds(&self, lhs: &Matrix<T, Self>, rhs: T) -> Matrix<T, Self> {
         cl_scalar_op_mat(self, lhs, rhs, "+").unwrap()

--- a/src/ops/scalar_assign.rs
+++ b/src/ops/scalar_assign.rs
@@ -1,6 +1,6 @@
 use crate::{assign_to_lhs_scalar, Matrix};
 use core::ops::{AddAssign, DivAssign, MulAssign, SubAssign};
-use custos::{impl_stack, CDatatype, Device, MainMemory, Shape, CPU};
+use custos::{impl_stack, number::Number, CDatatype, Device, MainMemory, Shape, CPU};
 
 #[cfg(feature = "stack")]
 use custos::Stack;
@@ -82,7 +82,7 @@ where
 }
 
 #[cfg(feature = "opencl")]
-impl<T: CDatatype> ScalarAssign<T> for OpenCL {
+impl<T: CDatatype + Number> ScalarAssign<T> for OpenCL {
     #[inline]
     fn adds_assign(&self, lhs: &mut Matrix<T, Self>, rhs: T) {
         cl_assign_scalar(self, lhs, rhs, "+").unwrap();
@@ -103,7 +103,7 @@ impl<T: CDatatype> ScalarAssign<T> for OpenCL {
 }
 
 #[cfg(feature = "cuda")]
-impl<T: CDatatype> ScalarAssign<T> for CUDA {
+impl<T: CDatatype + Number> ScalarAssign<T> for CUDA {
     #[inline]
     fn adds_assign(&self, lhs: &mut Matrix<T, CUDA>, rhs: T) {
         cu_assign_scalar(self, lhs, rhs, "+").unwrap();

--- a/src/ops/sum.rs
+++ b/src/ops/sum.rs
@@ -130,7 +130,7 @@ impl<T: Number> SumOps<T> for OpenCL {
 }
 
 #[cfg(feature = "opencl")]
-impl<T: CDatatype> SumOverOps<T> for OpenCL {
+impl<T: CDatatype + Number> SumOverOps<T> for OpenCL {
     #[inline]
     fn sum_rows<'a>(&'a self, x: &Matrix<T, Self>) -> Matrix<'a, T, Self> {
         cl_to_cpu_s(self, x, |device, x| device.sum_rows(x))
@@ -143,7 +143,7 @@ impl<T: CDatatype> SumOverOps<T> for OpenCL {
 }
 
 #[cfg(feature = "cuda")]
-impl<T: CDatatype> SumOps<T> for CUDA {
+impl<T: CDatatype + Number> SumOps<T> for CUDA {
     #[inline]
     fn sum(&self, x: &Matrix<T, CUDA>) -> T {
         cu_to_cpu_scalar(x, |device, x| device.sum(&x))
@@ -156,7 +156,7 @@ impl<T: CDatatype> SumOps<T> for CUDA {
 }
 
 #[cfg(feature = "cuda")]
-impl<T: CDatatype> SumOverOps<T> for CUDA {
+impl<T: CDatatype + Number> SumOverOps<T> for CUDA {
     #[inline]
     fn sum_rows(&self, x: &Matrix<T, CUDA>) -> Matrix<T, CUDA> {
         cu_to_cpu_s(self, x, |device, x| device.sum_rows(&x))

--- a/src/raw_ops/cuda/scalar_assign.rs
+++ b/src/raw_ops/cuda/scalar_assign.rs
@@ -1,6 +1,10 @@
-use custos::{cuda::launch_kernel1d, prelude::CUBuffer, CDatatype, CUDA};
+use custos::{
+    cuda::launch_kernel1d,
+    prelude::{CUBuffer, Number},
+    CDatatype, CUDA,
+};
 
-pub fn cu_assign_scalar<'a, T: CDatatype>(
+pub fn cu_assign_scalar<'a, T: CDatatype + Number>(
     device: &'a CUDA,
     lhs: &CUBuffer<T>,
     rhs: T,

--- a/src/raw_ops/opencl/scalar_assign.rs
+++ b/src/raw_ops/opencl/scalar_assign.rs
@@ -1,4 +1,4 @@
-use custos::{opencl::enqueue_kernel, prelude::CLBuffer, CDatatype, OpenCL};
+use custos::{number::Number, opencl::enqueue_kernel, prelude::CLBuffer, CDatatype, OpenCL};
 
 pub fn cl_assign_scalar<'a, T>(
     device: &'a OpenCL,
@@ -7,7 +7,7 @@ pub fn cl_assign_scalar<'a, T>(
     op: &str,
 ) -> custos::Result<()>
 where
-    T: CDatatype,
+    T: CDatatype + Number,
 {
     let src = format!(
         "

--- a/src/raw_ops/opencl/scalar_op.rs
+++ b/src/raw_ops/opencl/scalar_op.rs
@@ -1,4 +1,6 @@
-use custos::{opencl::enqueue_kernel, prelude::CLBuffer, CDatatype, Device, OpenCL};
+use custos::{
+    number::Number, opencl::enqueue_kernel, prelude::CLBuffer, CDatatype, Device, OpenCL,
+};
 
 pub fn cl_scalar_op<'a, T>(
     device: &'a OpenCL,
@@ -7,7 +9,7 @@ pub fn cl_scalar_op<'a, T>(
     op: &str,
 ) -> custos::Result<CLBuffer<'a, T>>
 where
-    T: CDatatype,
+    T: CDatatype + Number,
 {
     let src = format!("
     __kernel void scalar_r_op(__global const {datatype}* x, const {datatype} scalar, __global {datatype}* out) {{


### PR DESCRIPTION
This is to prepare for supporting a `Matrix<bool>` as the result of a comparison. The corresponding PR in `custos` is [#20](https://github.com/elftausend/custos/pull/20).